### PR TITLE
Implement grid design for mobile table

### DIFF
--- a/components/table.jsx
+++ b/components/table.jsx
@@ -87,7 +87,8 @@ export function TableCell({ className, children, ...props }) {
       className={clsx(
         className,
         'relative px-4 first:pl-(--gutter,--spacing(2)) last:pr-(--gutter,--spacing(2))',
-        !striped && 'border-b border-zinc-950/5 dark:border-white/5',
+        // Always show horizontal dividers when grid is enabled for clearer mobile layout
+        (grid || !striped) && 'border-b border-zinc-950/5 dark:border-white/5',
         grid && 'border-l border-l-zinc-950/5 first:border-l-0 dark:border-l-white/5',
         dense ? 'py-2.5' : 'py-4',
         !bleed && 'sm:first:pl-1 sm:last:pr-1'

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -105,7 +105,7 @@ export default async function Home() {
         <Heading level={1}>Horeca Weekly Board</Heading>
         <EditGate isEditor={editor} />
       </div>
-      <Table striped>
+      <Table grid striped>
         <TableHead>
           <TableRow>
             <TableHeader className="w-[28%]">Date</TableHeader>


### PR DESCRIPTION
Enable grid styling for the home page table and ensure full grid borders for better mobile readability on mobile.

---
Linear Issue: [K0D-255](https://linear.app/k0dominio/issue/K0D-255/grid-design)

<a href="https://cursor.com/background-agent?bcId=bc-87f57cf3-14b1-43ab-93b8-2ca9f5c99779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-87f57cf3-14b1-43ab-93b8-2ca9f5c99779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

