### PR TITLE
Adapt table to stacked card grid on mobile

### DIFF
--- a/components/table.jsx
+++ b/components/table.jsx
@@ -15,7 +15,7 @@ export function Table({ bleed = false, dense = false, grid = false, striped = fa
   return (
     <TableContext.Provider value={{ bleed, dense, grid, striped }}>
       <div className="flow-root">
-        <div {...props} className={clsx(className, '-mx-(--gutter) overflow-x-auto whitespace-nowrap')}>
+        <div {...props} className={clsx(className, '-mx-(--gutter) overflow-x-auto whitespace-normal sm:whitespace-nowrap')}>
           <div className={clsx('inline-block min-w-full align-middle', !bleed && 'sm:px-(--gutter)')}>
             <table className="min-w-full text-left text-sm/6 text-zinc-950 dark:text-white">{children}</table>
           </div>
@@ -26,11 +26,11 @@ export function Table({ bleed = false, dense = false, grid = false, striped = fa
 }
 
 export function TableHead({ className, ...props }) {
-  return <thead {...props} className={clsx(className, 'text-zinc-500 dark:text-zinc-400')} />
+  return <thead {...props} className={clsx(className, 'hidden text-zinc-500 dark:text-zinc-400 sm:table-header-group')} />
 }
 
-export function TableBody(props) {
-  return <tbody {...props} />
+export function TableBody({ className, ...props }) {
+  return <tbody {...props} className={clsx('grid grid-cols-1 gap-4 sm:table-row-group sm:gap-0', className)} />
 }
 
 const TableRowContext = createContext({
@@ -48,11 +48,13 @@ export function TableRow({ href, target, title, className, ...props }) {
         {...props}
         className={clsx(
           className,
+          // Mobile: show rows as cards; Desktop: keep table rows
+          'block rounded-xl border border-zinc-950/10 bg-white/70 p-4 shadow-sm dark:border-white/10 dark:bg-white/5 sm:table-row sm:rounded-none sm:border-0 sm:p-0 sm:shadow-none',
           href &&
             'has-[[data-row-link][data-focus]]:outline-2 has-[[data-row-link][data-focus]]:-outline-offset-2 has-[[data-row-link][data-focus]]:outline-blue-500 dark:focus-within:bg-white/2.5',
-          striped && 'even:bg-zinc-950/2.5 dark:even:bg-white/2.5',
-          href && striped && 'hover:bg-zinc-950/5 dark:hover:bg-white/5',
-          href && !striped && 'hover:bg-zinc-950/2.5 dark:hover:bg-white/2.5'
+          striped && 'sm:even:bg-zinc-950/2.5 dark:sm:even:bg-white/2.5',
+          href && striped && 'sm:hover:bg-zinc-950/5 dark:sm:hover:bg-white/5',
+          href && !striped && 'sm:hover:bg-zinc-950/2.5 dark:sm:hover:bg-white/2.5'
         )}
       />
     </TableRowContext.Provider>
@@ -75,7 +77,7 @@ export function TableHeader({ className, ...props }) {
   )
 }
 
-export function TableCell({ className, children, ...props }) {
+export function TableCell({ className, children, label, ...props }) {
   let { bleed, dense, grid, striped } = useContext(TableContext)
   let { href, target, title } = useContext(TableRowContext)
   let [cellRef, setCellRef] = useState(null)
@@ -86,11 +88,11 @@ export function TableCell({ className, children, ...props }) {
       {...props}
       className={clsx(
         className,
-        'relative px-4 first:pl-(--gutter,--spacing(2)) last:pr-(--gutter,--spacing(2))',
-        // Always show horizontal dividers when grid is enabled for clearer mobile layout
-        (grid || !striped) && 'border-b border-zinc-950/5 dark:border-white/5',
-        grid && 'border-l border-l-zinc-950/5 first:border-l-0 dark:border-l-white/5',
-        dense ? 'py-2.5' : 'py-4',
+        'relative block w-full px-0 py-2 sm:table-cell sm:px-4 sm:first:pl-(--gutter,--spacing(2)) sm:last:pr-(--gutter,--spacing(2))',
+        // Keep table borders on desktop only
+        (grid || !striped) && 'sm:border-b sm:border-zinc-950/5 dark:sm:border-white/5',
+        grid && 'sm:border-l sm:border-l-zinc-950/5 sm:first:border-l-0 dark:sm:border-l-white/5',
+        dense ? 'sm:py-2.5' : 'sm:py-4',
         !bleed && 'sm:first:pl-1 sm:last:pr-1'
       )}
     >
@@ -104,6 +106,7 @@ export function TableCell({ className, children, ...props }) {
           className="absolute inset-0 focus:outline-hidden"
         />
       )}
+      {label ? <div className="mb-1 text-xs font-medium text-zinc-500 sm:hidden">{label}</div> : null}
       {children}
     </td>
   )

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -123,26 +123,26 @@ export default async function Home() {
             const eventTitle = d.eventEntries?.[0]?.title || "";
             return (
               <TableRow key={d.id} href={`/day/${formatYmd(d.dateISO)}`}>
-                <TableCell>
+                <TableCell label="Date">
                   <div className="flex items-center gap-2">
                     <span>{formatDayDisplay(d.dateISO)}</span>
                     {golfTitle ? <Badge color="emerald">Golf</Badge> : null}
                     {eventTitle ? <Badge color="sky">Event</Badge> : null}
                   </div>
                 </TableCell>
-                <TableCell>
+                <TableCell label="PDJ">
                   <div className="flex items-center gap-2">
                     <Badge color={pdj.ambiguous ? "amber" : "zinc"}>{pdj.pattern}</Badge>
                     <span className="text-zinc-500">Total {pdj.total}</span>
                   </div>
                 </TableCell>
-                <TableCell className="hidden sm:table-cell">
+                <TableCell label="HTL Guests">
                   {hotel > 0 ? <Badge color="zinc">{hotel}</Badge> : <span className="text-zinc-500">—</span>}
                 </TableCell>
-                <TableCell className="hidden sm:table-cell">
+                <TableCell label="Golf">
                   {golfTitle ? <span>{golfTitle}</span> : <span className="text-zinc-500">—</span>}
                 </TableCell>
-                <TableCell className="hidden sm:table-cell">
+                <TableCell label="Event">
                   {eventTitle ? <span>{eventTitle}</span> : <span className="text-zinc-500">—</span>}
                 </TableCell>
               </TableRow>


### PR DESCRIPTION
Transform tables into a stacked card grid layout on mobile screens to improve readability and user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-32d4352c-8ead-46c6-9629-63b45eecb9ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-32d4352c-8ead-46c6-9629-63b45eecb9ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

