### PR TITLE
Update day view titles and compact cards

### DIFF
--- a/components/table.jsx
+++ b/components/table.jsx
@@ -30,7 +30,13 @@ export function TableHead({ className, ...props }) {
 }
 
 export function TableBody({ className, ...props }) {
-  return <tbody {...props} className={clsx('grid grid-cols-1 gap-4 sm:table-row-group sm:gap-0', className)} />
+  let { dense } = useContext(TableContext)
+  return (
+    <tbody
+      {...props}
+      className={clsx('grid grid-cols-1', dense ? 'gap-2' : 'gap-4', 'sm:table-row-group sm:gap-0', className)}
+    />
+  )
 }
 
 const TableRowContext = createContext({
@@ -40,7 +46,7 @@ const TableRowContext = createContext({
 })
 
 export function TableRow({ href, target, title, className, ...props }) {
-  let { striped } = useContext(TableContext)
+  let { striped, dense } = useContext(TableContext)
 
   return (
     <TableRowContext.Provider value={{ href, target, title }}>
@@ -49,7 +55,11 @@ export function TableRow({ href, target, title, className, ...props }) {
         className={clsx(
           className,
           // Mobile: show rows as cards; Desktop: keep table rows
-          'block rounded-xl border border-zinc-950/10 bg-white/70 p-4 shadow-sm dark:border-white/10 dark:bg-white/5 sm:table-row sm:rounded-none sm:border-0 sm:p-0 sm:shadow-none',
+          clsx(
+            'block rounded-xl border border-zinc-950/10 bg-white/70 shadow-sm dark:border-white/10 dark:bg-white/5',
+            dense ? 'p-3' : 'p-4',
+            'sm:table-row sm:rounded-none sm:border-0 sm:p-0 sm:shadow-none'
+          ),
           href &&
             'has-[[data-row-link][data-focus]]:outline-2 has-[[data-row-link][data-focus]]:-outline-offset-2 has-[[data-row-link][data-focus]]:outline-blue-500 dark:focus-within:bg-white/2.5',
           striped && 'sm:even:bg-zinc-950/2.5 dark:sm:even:bg-white/2.5',

--- a/src/app/day/[date]/page.js
+++ b/src/app/day/[date]/page.js
@@ -44,7 +44,7 @@ export default async function DayPage({ params }) {
       
       <div className="space-y-6">
         <section>
-          <Subheading level={2} className="mb-2">PDJ Groups</Subheading>
+          <Subheading level={2} className="mb-2">Breakfast</Subheading>
           <div className="flex flex-wrap gap-2">
             {day?.pdjGroups?.length ? day.pdjGroups.map((g) => (
               <Badge key={g.id}>{g.size}{g.label ? ` ${g.label}` : ''}</Badge>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -105,14 +105,14 @@ export default async function Home() {
         <Heading level={1}>Horeca Weekly Board</Heading>
         <EditGate isEditor={editor} />
       </div>
-      <Table grid striped>
+      <Table grid dense striped>
         <TableHead>
           <TableRow>
             <TableHeader className="w-[28%]">Date</TableHeader>
-            <TableHeader>PDJ</TableHeader>
-            <TableHeader className="hidden sm:table-cell">HTL Guests</TableHeader>
+            <TableHeader>Breakfast</TableHeader>
+            <TableHeader className="hidden sm:table-cell">Hotel Guests</TableHeader>
             <TableHeader className="hidden sm:table-cell">Golf</TableHeader>
-            <TableHeader className="hidden sm:table-cell">Event</TableHeader>
+            <TableHeader className="hidden sm:table-cell">Events</TableHeader>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -127,22 +127,22 @@ export default async function Home() {
                   <div className="flex items-center gap-2">
                     <span>{formatDayDisplay(d.dateISO)}</span>
                     {golfTitle ? <Badge color="emerald">Golf</Badge> : null}
-                    {eventTitle ? <Badge color="sky">Event</Badge> : null}
+                    {eventTitle ? <Badge color="sky">Events</Badge> : null}
                   </div>
                 </TableCell>
-                <TableCell label="PDJ">
+                <TableCell label="Breakfast">
                   <div className="flex items-center gap-2">
                     <Badge color={pdj.ambiguous ? "amber" : "zinc"}>{pdj.pattern}</Badge>
                     <span className="text-zinc-500">Total {pdj.total}</span>
                   </div>
                 </TableCell>
-                <TableCell label="HTL Guests">
+                <TableCell label="Hotel Guests">
                   {hotel > 0 ? <Badge color="zinc">{hotel}</Badge> : <span className="text-zinc-500">—</span>}
                 </TableCell>
                 <TableCell label="Golf">
                   {golfTitle ? <span>{golfTitle}</span> : <span className="text-zinc-500">—</span>}
                 </TableCell>
-                <TableCell label="Event">
+                <TableCell label="Events">
                   {eventTitle ? <span>{eventTitle}</span> : <span className="text-zinc-500">—</span>}
                 </TableCell>
               </TableRow>


### PR DESCRIPTION
Update day view and weekly board titles and make weekly cards more compact to match requested nomenclature and improve screen density.

---
<a href="https://cursor.com/background-agent?bcId=bc-a18cad29-3787-490d-964b-ea4c188d12a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a18cad29-3787-490d-964b-ea4c188d12a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

